### PR TITLE
Align SLES 15 SSH defaults with vendor templates

### DIFF
--- a/data/os/SLES/15.yaml
+++ b/data/os/SLES/15.yaml
@@ -1,72 +1,26 @@
 ---
 # (Suse) SLES 15 defaults in alphabetical order per class
 ssh::forward_x11_trusted: 'yes'
-ssh::gss_api_authentication: 'yes'
-ssh::hash_known_hosts: 'no'
 ssh::host: '*'
 ssh::packages:
   - 'openssh'
 ssh::send_env:
-  - 'LANG'
-  - 'LANGUAGE'
-  - 'LC_ADDRESS'
-  - 'LC_ALL'
-  - 'LC_COLLATE'
-  - 'LC_CTYPE'
-  - 'LC_IDENTIFICATION'
-  - 'LC_MEASUREMENT'
-  - 'LC_MESSAGES'
-  - 'LC_MONETARY'
-  - 'LC_NAME'
-  - 'LC_NUMERIC'
-  - 'LC_PAPER'
-  - 'LC_TELEPHONE'
-  - 'LC_TIME'
+  - 'LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES'
+  - 'LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT'
+  - 'LC_IDENTIFICATION LC_ALL'
 
 ssh::server::accept_env:
-  - 'LANG'
-  - 'LC_ADDRESS'
-  - 'LC_ALL'
-  - 'LC_COLLATE'
-  - 'LC_CTYPE'
-  - 'LC_IDENTIFICATION'
-  - 'LC_MEASUREMENT'
-  - 'LC_MESSAGES'
-  - 'LC_MONETARY'
-  - 'LC_NAME'
-  - 'LC_NUMERIC'
-  - 'LC_PAPER'
-  - 'LC_TELEPHONE'
-  - 'LC_TIME'
+  - 'LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES'
+  - 'LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT'
+  - 'LC_IDENTIFICATION LC_ALL'
 
-ssh::server::address_family: 'any'
-ssh::server::allow_tcp_forwarding: 'yes'
-ssh::server::banner: 'none'
-ssh::server::kbd_interactive_authentication: 'yes'
-ssh::server::client_alive_count_max: 3
-ssh::server::client_alive_interval: 0
-ssh::server::gss_api_authentication: 'yes'
-ssh::server::gss_api_cleanup_credentials: 'yes'
-ssh::server::hostbased_authentication: 'no'
-ssh::server::host_key:
-  - '/etc/ssh/ssh_host_rsa_key'
-ssh::server::ignore_rhosts: 'yes'
-ssh::server::ignore_user_known_hosts: 'no'
-ssh::server::login_grace_time: 120
-#ssh::server::packages:
-#  - 'openssh'
-ssh::server::password_authentication: 'yes'
+ssh::server::authorized_keys_file:
+  - '.ssh/authorized_keys'
+
+ssh::server::client_alive_interval: 180
+
 ssh::server::permit_root_login: 'yes'
-ssh::server::permit_tunnel: 'no'
-ssh::server::port:
-  - 22
-ssh::server::print_motd: 'yes'
-ssh::server::pubkey_authentication: 'yes'
+ssh::server::print_motd: 'no'
 ssh::server::subsystem: 'sftp /usr/lib/ssh/sftp-server'
-ssh::server::syslog_facility: 'AUTH'
-ssh::server::tcp_keep_alive: 'yes'
-ssh::server::use_dns: 'yes'
 ssh::server::use_pam: 'yes'
 ssh::server::x11_forwarding: 'yes'
-ssh::server::x11_use_localhost: 'yes'
-ssh::server::xauth_location: '/usr/bin/xauth'

--- a/metadata.json
+++ b/metadata.json
@@ -70,6 +70,15 @@
       ]
     },
     {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "10",
+        "11",
+        "12",
+        "15"
+      ]
+    },
+    {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
         "7",

--- a/spec/classes/server_params_spec.rb
+++ b/spec/classes/server_params_spec.rb
@@ -135,7 +135,7 @@ describe 'ssh::server' do
   end
 
   ['SLED', 'SLES'].each do |name|
-    ['10', '11', '12'].each do |major|
+    ['10', '11', '12', '15'].each do |major|
       context "on #{name} #{major} with i386 architecture path for sftp subsystem is /usr/lib/ssh/sftp-server" do
         let(:facts) do
           {

--- a/spec/fixtures/testing/SLES-15_ssh_config
+++ b/spec/fixtures/testing/SLES-15_ssh_config
@@ -1,0 +1,10 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+#
+# See https://man.openbsd.org/ssh_config for more info
+
+Host *
+  ForwardX11Trusted yes
+  SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
+  SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
+  SendEnv LC_IDENTIFICATION LC_ALL

--- a/spec/fixtures/testing/SLES-15_sshd_config
+++ b/spec/fixtures/testing/SLES-15_sshd_config
@@ -1,0 +1,15 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+#
+# See https://man.openbsd.org/sshd_config for more info
+
+AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
+AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
+AcceptEnv LC_IDENTIFICATION LC_ALL
+AuthorizedKeysFile .ssh/authorized_keys
+ClientAliveInterval 180
+PermitRootLogin yes
+PrintMotd no
+Subsystem sftp /usr/lib/ssh/sftp-server
+UsePAM yes
+X11Forwarding yes


### PR DESCRIPTION
## Summary
- align the SLES 15 SSH client and server defaults with the vendor-provided configuration templates
- refresh the SLES 15 fixture configs to mirror the upstream AcceptEnv, SendEnv, PrintMotd, and ClientAliveInterval settings

## Testing
- bundle exec rake spec *(fails: Could not find gem 'voxpupuli-test (= 6.0.0)' in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_68e50ce202788328b4997cd0a7a8db5f