### PR TITLE
Handle multiple include globs for SLES 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [Unreleased]
+
+### Added
+
+- Align the SLES 15 SSH defaults and fixtures with the vendor-provided configuration templates.
+- Document SLES 10–15 among the supported platforms.
+
 ## [v5.1.1](https://github.com/ghoneycutt/puppet-module-ssh/tree/v5.1.1) (2024-12-30)
 
 [Full Changelog](https://github.com/ghoneycutt/puppet-module-ssh/compare/v5.1.0...v5.1.1)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ known to work on many, many platforms since its creation in 2010.
  * EL 7
  * EL 8
  * EL 9
+ * SLES 10
+ * SLES 11
+ * SLES 12
+ * SLES 15
  * Ubuntu 18.04 LTS
  * Ubuntu 20.04 LTS
  * Ubuntu 22.04 LTS

--- a/data/os/SLES/15.yaml
+++ b/data/os/SLES/15.yaml
@@ -1,72 +1,32 @@
 ---
 # (Suse) SLES 15 defaults in alphabetical order per class
 ssh::forward_x11_trusted: 'yes'
-ssh::gss_api_authentication: 'yes'
-ssh::hash_known_hosts: 'no'
 ssh::host: '*'
+ssh::include:
+  - '/etc/ssh/ssh_config.d/*.conf'
+  - '/usr/etc/ssh/ssh_config.d/*.conf'
 ssh::packages:
   - 'openssh'
+# SLES 15 groups the locale SendEnv directives across three lines.
 ssh::send_env:
-  - 'LANG'
-  - 'LANGUAGE'
-  - 'LC_ADDRESS'
-  - 'LC_ALL'
-  - 'LC_COLLATE'
-  - 'LC_CTYPE'
-  - 'LC_IDENTIFICATION'
-  - 'LC_MEASUREMENT'
-  - 'LC_MESSAGES'
-  - 'LC_MONETARY'
-  - 'LC_NAME'
-  - 'LC_NUMERIC'
-  - 'LC_PAPER'
-  - 'LC_TELEPHONE'
-  - 'LC_TIME'
+  - 'LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES'
+  - 'LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT'
+  - 'LC_IDENTIFICATION LC_ALL'
 
+# SLES 15 groups the locale AcceptEnv directives across the same three lines.
 ssh::server::accept_env:
-  - 'LANG'
-  - 'LC_ADDRESS'
-  - 'LC_ALL'
-  - 'LC_COLLATE'
-  - 'LC_CTYPE'
-  - 'LC_IDENTIFICATION'
-  - 'LC_MEASUREMENT'
-  - 'LC_MESSAGES'
-  - 'LC_MONETARY'
-  - 'LC_NAME'
-  - 'LC_NUMERIC'
-  - 'LC_PAPER'
-  - 'LC_TELEPHONE'
-  - 'LC_TIME'
+  - 'LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES'
+  - 'LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT'
+  - 'LC_IDENTIFICATION LC_ALL'
 
-ssh::server::address_family: 'any'
-ssh::server::allow_tcp_forwarding: 'yes'
-ssh::server::banner: 'none'
-ssh::server::kbd_interactive_authentication: 'yes'
-ssh::server::client_alive_count_max: 3
-ssh::server::client_alive_interval: 0
-ssh::server::gss_api_authentication: 'yes'
-ssh::server::gss_api_cleanup_credentials: 'yes'
-ssh::server::hostbased_authentication: 'no'
-ssh::server::host_key:
-  - '/etc/ssh/ssh_host_rsa_key'
-ssh::server::ignore_rhosts: 'yes'
-ssh::server::ignore_user_known_hosts: 'no'
-ssh::server::login_grace_time: 120
-#ssh::server::packages:
-#  - 'openssh'
-ssh::server::password_authentication: 'yes'
+ssh::server::authorized_keys_file:
+  - '.ssh/authorized_keys'
+ssh::server::client_alive_interval: 180
+ssh::server::include:
+  - '/etc/ssh/sshd_config.d/*.conf'
+  - '/usr/etc/ssh/sshd_config.d/*.conf'
 ssh::server::permit_root_login: 'yes'
-ssh::server::permit_tunnel: 'no'
-ssh::server::port:
-  - 22
-ssh::server::print_motd: 'yes'
-ssh::server::pubkey_authentication: 'yes'
+ssh::server::print_motd: 'no'
 ssh::server::subsystem: 'sftp /usr/lib/ssh/sftp-server'
-ssh::server::syslog_facility: 'AUTH'
-ssh::server::tcp_keep_alive: 'yes'
-ssh::server::use_dns: 'yes'
 ssh::server::use_pam: 'yes'
 ssh::server::x11_forwarding: 'yes'
-ssh::server::x11_use_localhost: 'yes'
-ssh::server::xauth_location: '/usr/bin/xauth'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -622,17 +622,27 @@ class ssh (
   }
 
   if $include {
-    $include_dir = dirname($include)
-    file { 'ssh_config_include_dir':
-      ensure  => 'directory',
-      path    => $include_dir,
-      owner   => $include_dir_owner,
-      group   => $include_dir_group,
-      mode    => $include_dir_mode,
-      purge   => $include_dir_purge,
-      recurse => $include_dir_purge,
-      force   => $include_dir_purge,
-      require => $packages_require,
+    case $include {
+      String: {
+        $include_dir = dirname($include)
+        file { 'ssh_config_include_dir':
+          ensure  => 'directory',
+          path    => $include_dir,
+          owner   => $include_dir_owner,
+          group   => $include_dir_group,
+          mode    => $include_dir_mode,
+          purge   => $include_dir_purge,
+          recurse => $include_dir_purge,
+          force   => $include_dir_purge,
+          require => $packages_require,
+        }
+      }
+      Array: {
+        $include_dir = undef
+      }
+      default: {
+        $include_dir = undef
+      }
     }
   } else {
     $include_dir = undef

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -621,18 +621,28 @@ class ssh::server (
   }
 
   if $include {
-    $include_dir = dirname($include)
-    file { 'sshd_config_include_dir':
-      ensure  => 'directory',
-      path    => $include_dir,
-      owner   => $include_dir_owner,
-      group   => $include_dir_group,
-      mode    => $include_dir_mode,
-      purge   => $include_dir_purge,
-      recurse => $include_dir_purge,
-      force   => $include_dir_purge,
-      require => $packages_require,
-      notify  => $notify_service,
+    case $include {
+      String: {
+        $include_dir = dirname($include)
+        file { 'sshd_config_include_dir':
+          ensure  => 'directory',
+          path    => $include_dir,
+          owner   => $include_dir_owner,
+          group   => $include_dir_group,
+          mode    => $include_dir_mode,
+          purge   => $include_dir_purge,
+          recurse => $include_dir_purge,
+          force   => $include_dir_purge,
+          require => $packages_require,
+          notify  => $notify_service,
+        }
+      }
+      Array: {
+        $include_dir = undef
+      }
+      default: {
+        $include_dir = undef
+      }
     }
   } else {
     $include_dir = undef

--- a/metadata.json
+++ b/metadata.json
@@ -70,6 +70,15 @@
       ]
     },
     {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "10",
+        "11",
+        "12",
+        "15"
+      ]
+    },
+    {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
         "7",

--- a/spec/classes/server_params_spec.rb
+++ b/spec/classes/server_params_spec.rb
@@ -135,7 +135,7 @@ describe 'ssh::server' do
   end
 
   ['SLED', 'SLES'].each do |name|
-    ['10', '11', '12'].each do |major|
+    ['10', '11', '12', '15'].each do |major|
       context "on #{name} #{major} with i386 architecture path for sftp subsystem is /usr/lib/ssh/sftp-server" do
         let(:facts) do
           {

--- a/spec/fixtures/testing/SLES-15_ssh_config
+++ b/spec/fixtures/testing/SLES-15_ssh_config
@@ -1,0 +1,12 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+#
+# See https://man.openbsd.org/ssh_config for more info
+
+Host *
+  ForwardX11Trusted yes
+  Include /etc/ssh/ssh_config.d/*.conf
+  Include /usr/etc/ssh/ssh_config.d/*.conf
+  SendEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
+  SendEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
+  SendEnv LC_IDENTIFICATION LC_ALL

--- a/spec/fixtures/testing/SLES-15_sshd_config
+++ b/spec/fixtures/testing/SLES-15_sshd_config
@@ -1,0 +1,17 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+#
+# See https://man.openbsd.org/sshd_config for more info
+
+Include /etc/ssh/sshd_config.d/*.conf
+Include /usr/etc/ssh/sshd_config.d/*.conf
+AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
+AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
+AcceptEnv LC_IDENTIFICATION LC_ALL
+AuthorizedKeysFile .ssh/authorized_keys
+ClientAliveInterval 180
+PermitRootLogin yes
+PrintMotd no
+Subsystem sftp /usr/lib/ssh/sftp-server
+UsePAM yes
+X11Forwarding yes

--- a/templates/ssh_config.erb
+++ b/templates/ssh_config.erb
@@ -146,7 +146,9 @@ Host <%= @host %>
   IgnoreUnknown <%= @ignore_unknown.join(',') %>
 <% end -%>
 <% if @include != nil -%>
-  Include <%= @include %>
+<%   Array(@include).each do |v| -%>
+  Include <%= v %>
+<%   end -%>
 <% end -%>
 <% if @ip_qos != nil -%>
   IPQoS <%= @ip_qos %>

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -4,7 +4,9 @@
 # See https://man.openbsd.org/sshd_config for more info
 
 <% if @include != nil -%>
-Include <%= @include %>
+<%   Array(@include).each do |v| -%>
+Include <%= v %>
+<%   end -%>
 <% end -%>
 <% if @accept_env != nil -%>
 <%   @accept_env.each do |v| -%>


### PR DESCRIPTION
## Summary
- model the vendor ssh/sshd include directives for SLES 15 as distinct entries so the fixtures match the platform templates
- teach the ssh client and server templates to render multiple Include lines and avoid managing include directories when arrays are supplied

## Testing
- bundle exec rake spec *(fails: Could not find gem 'voxpupuli-test (= 6.0.0)' in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_68e50ce202788328b4997cd0a7a8db5f