### PR TITLE
Handle missing SSH version matches gracefully

### DIFF
--- a/lib/facter/ssh.rb
+++ b/lib/facter/ssh.rb
@@ -3,7 +3,7 @@ Facter.add('ssh_version') do
     next unless Facter::Util::Resolution.which('ssh')
 
     version_output = Facter::Util::Resolution.exec('ssh -V 2>&1')
-    match = version_output&.match(%r{[A-Za-z0-9._]+SSH[A-Za-z0-9._]+})
+    match = version_output&.match(%r{[A-Za-z0-9._+-]*SSH[A-Za-z0-9._+-]*})
     match[0] if match
   end
 end

--- a/lib/facter/ssh.rb
+++ b/lib/facter/ssh.rb
@@ -1,16 +1,17 @@
 Facter.add('ssh_version') do
   setcode do
-    if Facter::Util::Resolution.which('ssh')
-      Facter::Util::Resolution.exec('ssh -V 2>&1').match(%r{^[A-Za-z0-9._]+SSH[A-Za-z0-9._]+})[0]
-    end
+    next unless Facter::Util::Resolution.which('ssh')
+
+    version_output = Facter::Util::Resolution.exec('ssh -V 2>&1')
+    match = version_output&.match(%r{^[A-Za-z0-9._]+SSH[A-Za-z0-9._]+})
+    match[0] if match
   end
 end
 
 Facter.add('ssh_version_numeric') do
   setcode do
     ssh_version = Facter.value(:ssh_version)
-    if ssh_version
-      ssh_version.match(%r{(\d+\.\d+\.\d+|\d+\.\d+)})[0]
-    end
+    match = ssh_version&.match(%r{(\d+\.\d+\.\d+|\d+\.\d+)})
+    match[0] if match
   end
 end

--- a/lib/facter/ssh.rb
+++ b/lib/facter/ssh.rb
@@ -3,7 +3,7 @@ Facter.add('ssh_version') do
     next unless Facter::Util::Resolution.which('ssh')
 
     version_output = Facter::Util::Resolution.exec('ssh -V 2>&1')
-    match = version_output&.match(%r{^[A-Za-z0-9._]+SSH[A-Za-z0-9._]+})
+    match = version_output&.match(%r{[A-Za-z0-9._]+SSH[A-Za-z0-9._]+})
     match[0] if match
   end
 end

--- a/lib/facter/ssh.rb
+++ b/lib/facter/ssh.rb
@@ -3,8 +3,28 @@ Facter.add('ssh_version') do
     next unless Facter::Util::Resolution.which('ssh')
 
     version_output = Facter::Util::Resolution.exec('ssh -V 2>&1')
-    match = version_output&.match(%r{[A-Za-z0-9._+-]*SSH[A-Za-z0-9._+-]*})
-    match[0] if match
+    next unless version_output
+
+    tokens = version_output.split(/[,\s]+/)
+    token_pattern = %r{\A[A-Za-z0-9._+-]*SSH[A-Za-z0-9._+-]*\z}
+
+    preferred_version = tokens.find do |token|
+      token.match?(token_pattern) && token.match?(%r{\A(?:Open|Sun_)?SSH})
+    end
+
+    preferred_version ||= tokens.filter_map do |token|
+      next unless token.include?('OpenSSH_')
+
+      token[%r{OpenSSH_[A-Za-z0-9._+-]*}]
+    end.first
+
+    preferred_version ||= tokens.filter_map do |token|
+      next unless token.include?('Sun_SSH_')
+
+      token[%r{Sun_SSH_[A-Za-z0-9._+-]*}]
+    end.first
+
+    preferred_version || tokens.find { |token| token.match?(token_pattern) }
   end
 end
 

--- a/spec/unit/facter/ssh_spec.rb
+++ b/spec/unit/facter/ssh_spec.rb
@@ -10,6 +10,8 @@ describe 'Facter::Util::Fact' do
     'Sun_SSH_1.1, SSH protocols 1.5/2.0, OpenSSL 0x0090700f' =>     { ssh_version: 'Sun_SSH_1.1',     ssh_version_numeric: '1.1' },   # Solaris 9 SPARC
     'Sun_SSH_1.1.5, SSH protocols 1.5/2.0, OpenSSL 0x0090704f' =>   { ssh_version: 'Sun_SSH_1.1.5',   ssh_version_numeric: '1.1.5' }, # Solaris 10 SPARC
     "linebreak\nOpenSSH_8.0p1, OpenSSL 1.1.1c FIPS  28 May 2019" => { ssh_version: 'OpenSSH_8.0p1',   ssh_version_numeric: '8.0' },   # with extra line
+    "banner\nnotice\nOpenSSH_9.6p1 Ubuntu-3ubuntu13.13, OpenSSL 3.0.13 30 Jan 2024" => { ssh_version: 'OpenSSH_9.6p1',   ssh_version_numeric: '9.6' },
+    "warning\nOpenSSH_for_Windows_9.2p1, LibreSSL 3.0.2" =>                            { ssh_version: 'OpenSSH_for_Windows_9.2p1', ssh_version_numeric: '9.2' },
     'broken string' =>                                              { ssh_version: nil,               ssh_version_numeric: nil },
   }
 


### PR DESCRIPTION
## Summary
- guard ssh version facts against unexpected command output so they return nil instead of raising errors

## Testing
- bundle exec rake spec *(fails: Could not find gem 'voxpupuli-test (= 6.0.0)')*


------
https://chatgpt.com/codex/tasks/task_e_68e62f1855648328a525f217cf7da913